### PR TITLE
Fix scrubber and write a spec for it

### DIFF
--- a/client/js/middleware/serialization/serializer_utils.js
+++ b/client/js/middleware/serialization/serializer_utils.js
@@ -3,14 +3,16 @@ import $    from 'jquery';
 import genusTypes from '../../constants/genus_types';
 
 export function scrub(item, protectedKeys) {
-  let scrubbedItem = _.cloneDeep(item);
-  scrubbedItem = _.omitBy(scrubbedItem, (val, key) => (
-    _.isNil(val) && !_.includes(protectedKeys, key)
+  if (_.isPlainObject(item)) {
+    return _.omitBy(item, (val, key) => (
+      (_.isNil(val) && !_.includes(protectedKeys, key))
+      || (_.isObject(val) && _.isEmpty(val) && !_.includes(protectedKeys, key))
+    ));
+  }
+
+  return _.reject(item, val => (
+    _.isNil(val) || (_.isObject(val) && _.isEmpty(val))
   ));
-  scrubbedItem = _.omitBy(scrubbedItem, (val, key) => (
-    _.isObject(val) && _.isEmpty(val) && !_.includes(protectedKeys, key)
-  ));
-  return scrubbedItem;
 }
 
 export function getSingleCorrectAnswer(originalItem, question) {

--- a/client/js/middleware/serialization/serializer_utils.spec.js
+++ b/client/js/middleware/serialization/serializer_utils.spec.js
@@ -1,0 +1,28 @@
+import _          from 'lodash';
+import { scrub }  from './serializer_utils';
+
+describe('scrub', () => {
+  describe('arrays', () => {
+    it('returns an array when it is passed an array', () => {
+      expect(_.isArray(scrub([]))).toBeTruthy();
+    });
+
+    it('removes falsey and empty values', () => {
+      expect(scrub([null, undefined, {}, []])).toEqual([]);
+    });
+  })
+
+  describe('objects', () => {
+    it('returns an object when it is passed an array', () => {
+      expect(_.isPlainObject(scrub({}))).toBeTruthy();
+    });
+
+    it('removes falsey and empty values', () => {
+      expect(scrub({ a: null, b: undefined, c: {}, d: [] })).toEqual({});
+    });
+
+    it('excludes specified keys', () => {
+      expect(scrub({ a: null, b: undefined, c: {}, d: [] }, ['a'])).toEqual({ a: null });
+    });
+  });
+});

--- a/client/js/middleware/serialization/serializer_utils.spec.js
+++ b/client/js/middleware/serialization/serializer_utils.spec.js
@@ -10,7 +10,7 @@ describe('scrub', () => {
     it('removes falsey and empty values', () => {
       expect(scrub([null, undefined, {}, []])).toEqual([]);
     });
-  })
+  });
 
   describe('objects', () => {
     it('returns an object when it is passed an array', () => {

--- a/client/js/middleware/serialization/serializer_utils.spec.js
+++ b/client/js/middleware/serialization/serializer_utils.spec.js
@@ -2,27 +2,23 @@ import _          from 'lodash';
 import { scrub }  from './serializer_utils';
 
 describe('scrub', () => {
-  describe('arrays', () => {
-    it('returns an array when it is passed an array', () => {
-      expect(_.isArray(scrub([]))).toBeTruthy();
-    });
-
-    it('removes falsey and empty values', () => {
-      expect(scrub([null, undefined, {}, []])).toEqual([]);
-    });
+  it('returns an array when it is passed an array', () => {
+    expect(_.isArray(scrub([]))).toBeTruthy();
   });
 
-  describe('objects', () => {
-    it('returns an object when it is passed an array', () => {
-      expect(_.isPlainObject(scrub({}))).toBeTruthy();
-    });
+  it('removes falsey and empty values from arrays', () => {
+    expect(scrub([null, undefined, {}, []])).toEqual([]);
+  });
 
-    it('removes falsey and empty values', () => {
-      expect(scrub({ a: null, b: undefined, c: {}, d: [] })).toEqual({});
-    });
+  it('returns an object when it is passed an object', () => {
+    expect(_.isPlainObject(scrub({}))).toBeTruthy();
+  });
 
-    it('excludes specified keys', () => {
-      expect(scrub({ a: null, b: undefined, c: {}, d: [] }, ['a'])).toEqual({ a: null });
-    });
+  it('removes falsey and empty values from objects', () => {
+    expect(scrub({ a: null, b: undefined, c: {}, d: [] })).toEqual({});
+  });
+
+  it('excludes specified keys from objects', () => {
+    expect(scrub({ a: null, b: undefined, c: {}, d: [] }, ['a'])).toEqual({ a: null });
   });
 });


### PR DESCRIPTION
Formerly we were using _.omitBy, which always returns an object, which was bad if we ran it on an array. _.reject always returns an array. Added some logic figuring out which one to use, and then a spec to verify that it does actually correctly scrub values.